### PR TITLE
Added playerstate 'LOADING'

### DIFF
--- a/Sharpcaster/Converters/PlayerStateEnumConverter.cs
+++ b/Sharpcaster/Converters/PlayerStateEnumConverter.cs
@@ -23,6 +23,9 @@ namespace Sharpcaster.Converters
                 case PlayerStateType.Playing:
                     writer.WriteValue("PLAYING");
                     break;
+                case PlayerStateType.Loading:
+                    writer.WriteValue("LOADING");
+                    break;
                 default:
                     throw new ArgumentOutOfRangeException();
             }
@@ -46,6 +49,9 @@ namespace Sharpcaster.Converters
                     break;
                 case "PLAYING":
                     playerState = PlayerStateType.Playing;
+                    break;
+                case "LOADING":
+                    playerState = PlayerStateType.Loading;
                     break;
             }
             return playerState;

--- a/Sharpcaster/Models/Media/PlayerStateType.cs
+++ b/Sharpcaster/Models/Media/PlayerStateType.cs
@@ -5,6 +5,7 @@
         Buffering,
         Idle,
         Paused,
-        Playing
+        Playing,
+        Loading
     }
 }


### PR DESCRIPTION
Adds the missing playerstate 'LOADING' that can be set in the extendedStatus.

I was getting the following exception whenever my chromecast would send a status message with that state:
```
Newtonsoft.Json.JsonSerializationException: Error setting value to 'PlayerState' on 'Sharpcaster.Models.Media.MediaStatus'. ---> System.NullReferenceException: Object reference not set to an instance of an object.
   at SetPlayerState(Object , Object )
   at Newtonsoft.Json.Serialization.DynamicValueProvider.SetValue(Object target, Object value)
```

Docs: https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.messages.MediaStatus#extendedStatus